### PR TITLE
User defined name in tally/count

### DIFF
--- a/R/count-tally.R
+++ b/R/count-tally.R
@@ -20,10 +20,7 @@
 #' will be called `nn`. If the table already has columns called `n` and `nn`
 #' then the column returned will be `nnn`, and so on.
 #'
-#' There is currently no way to control the output variable name - if you
-#' need to change the default,
-#' you can call [rename()] on the result,
-#' or write the [summarise()] yourself.
+#' To control the output column name use `name`.
 #'
 #' @param x a [tbl()] to tally/count.
 #' @param ... Variables to group by.
@@ -37,6 +34,7 @@
 #'   frame. It supports [unquoting][rlang::quasiquotation]. See
 #'   `vignette("programming")` for an introduction to these concepts.
 #' @param sort if `TRUE` will sort output in descending order of `n`
+#' @param name The output column name. If omitted, it will be `n`.
 #' @return A tbl, grouped the same way as `x`.
 #' @export
 #' @examples
@@ -59,22 +57,20 @@
 #' species
 #' species %>% count(species, sort = TRUE)
 #'
-#' # Use rename() to change the name of the newly created column:
+#' # Change the name of the newly created column:
 #' species <-
 #'  starwars %>%
-#'  count(species, homeworld, sort = TRUE) %>%
-#'  rename(n_species_by_homeworld = n)
+#'  count(species, homeworld, sort = TRUE, name = "n_species_by_homeworld")
 #' species
 #' species %>%
-#'  count(species, sort = TRUE) %>%
-#'  rename(n_species = n)
+#'  count(species, sort = TRUE, name = "n_species")
 #'
 #' # add_count() is useful for groupwise filtering
 #' # e.g.: show details for species that have a single member
 #' starwars %>%
 #'   add_count(species) %>%
 #'   filter(n == 1)
-tally <- function(x, wt, sort = FALSE) {
+tally <- function(x, wt, sort = FALSE, name = "n") {
   wt <- enquo(wt)
 
   if (quo_is_missing(wt) && "n" %in% tbl_vars(x)) {
@@ -88,7 +84,12 @@ tally <- function(x, wt, sort = FALSE) {
     n <- quo(sum(!!wt, na.rm = TRUE))
   }
 
-  n_name <- n_name(tbl_vars(x))
+  n_name <- n_name(tbl_vars(x), name)
+
+  if (name != "n" && name %in% tbl_vars(x)) {
+    inform(sprintf("Column `%s` already exists, using `%s` as output variable name", name, n_name))
+  }
+
   out <- summarise(x, !!n_name := !!n)
 
   if (sort) {
@@ -105,10 +106,9 @@ tally_ <- function(x, wt, sort = FALSE) {
   tally(x, wt = !!wt, sort = sort)
 }
 
-n_name <- function(x) {
-  name <- "n"
+n_name <- function(x, name = "n") {
   while (name %in% x) {
-    name <- paste0(name, "n")
+    name <- paste0("n", name)
   }
 
   name
@@ -116,11 +116,11 @@ n_name <- function(x) {
 
 #' @export
 #' @rdname tally
-count <- function(x, ..., wt = NULL, sort = FALSE) {
+count <- function(x, ..., wt = NULL, sort = FALSE, name = "n") {
   groups <- group_vars(x)
 
   x <- group_by(x, ..., add = TRUE)
-  x <- tally(x, wt = !!enquo(wt), sort = sort)
+  x <- tally(x, wt = !!enquo(wt), sort = sort, name = name)
   x <- group_by(x, !!!syms(groups), add = FALSE)
   x
 }
@@ -135,10 +135,10 @@ count_ <- function(x, vars, wt = NULL, sort = FALSE) {
 
 #' @rdname tally
 #' @export
-add_tally <- function(x, wt, sort = FALSE) {
+add_tally <- function(x, wt, sort = FALSE, name = "n") {
   wt <- enquo(wt)
 
-  if (quo_is_missing(wt) && "n" %in% names(x)) {
+  if (quo_is_missing(wt) && "n" %in% tbl_vars(x)) {
     inform("Using `n` as weighting variable")
     wt <- quo(n)
   }
@@ -149,7 +149,12 @@ add_tally <- function(x, wt, sort = FALSE) {
     n <- quo(sum(!!wt, na.rm = TRUE))
   }
 
-  n_name <- n_name(tbl_vars(x))
+  n_name <- n_name(tbl_vars(x), name)
+
+  if (name != "n" && name %in% tbl_vars(x)) {
+    inform(sprintf("Column `%s` already exists, using `%s` as output variable name", name, n_name))
+  }
+
   out <- mutate(x, !!n_name := !!n)
 
   if (sort) {
@@ -164,15 +169,13 @@ add_tally_ <- function(x, wt, sort = FALSE) {
   wt <- compat_lazy(wt, caller_env())
   add_tally(x, !!wt, sort = sort)
 }
-
-
 #' @rdname tally
 #' @export
-add_count <- function(x, ..., wt = NULL, sort = FALSE) {
+add_count <- function(x, ..., wt = NULL, sort = FALSE, name = "n") {
   g <- group_vars(x)
   grouped <- group_by(x, ..., add = TRUE)
 
-  out <- add_tally(grouped, wt = !!enquo(wt), sort = sort)
+  out <- add_tally(grouped, wt = !!enquo(wt), sort = sort, name = name)
   out <- grouped_df(out, g)
   if (length(groups(out)) == 0L) {
     out <- ungroup(out)

--- a/man/tally.Rd
+++ b/man/tally.Rd
@@ -7,13 +7,13 @@
 \alias{add_count}
 \title{Count/tally observations by group}
 \usage{
-tally(x, wt, sort = FALSE)
+tally(x, wt, sort = FALSE, name = "n")
 
-count(x, ..., wt = NULL, sort = FALSE)
+count(x, ..., wt = NULL, sort = FALSE, name = "n")
 
-add_tally(x, wt, sort = FALSE)
+add_tally(x, wt, sort = FALSE, name = "n")
 
-add_count(x, ..., wt = NULL, sort = FALSE)
+add_count(x, ..., wt = NULL, sort = FALSE, name = "n")
 }
 \arguments{
 \item{x}{a \code{\link[=tbl]{tbl()}} to tally/count.}
@@ -29,6 +29,8 @@ frame. It supports \link[rlang:quasiquotation]{unquoting}. See
 \code{vignette("programming")} for an introduction to these concepts.}
 
 \item{sort}{if \code{TRUE} will sort output in descending order of \code{n}}
+
+\item{name}{The output column name. If omitted, it will be \code{n}.}
 
 \item{...}{Variables to group by.}
 }
@@ -55,10 +57,7 @@ If the data already has a column named \code{n}, the output column
 will be called \code{nn}. If the table already has columns called \code{n} and \code{nn}
 then the column returned will be \code{nnn}, and so on.
 
-There is currently no way to control the output variable name - if you
-need to change the default,
-you can call \code{\link[=rename]{rename()}} on the result,
-or write the \code{\link[=summarise]{summarise()}} yourself.
+To control the output column name use \code{name}.
 }
 \examples{
 # tally() is short-hand for summarise()
@@ -80,15 +79,13 @@ species <-
 species
 species \%>\% count(species, sort = TRUE)
 
-# Use rename() to change the name of the newly created column:
+# Change the name of the newly created column:
 species <-
  starwars \%>\%
- count(species, homeworld, sort = TRUE) \%>\%
- rename(n_species_by_homeworld = n)
+ count(species, homeworld, sort = TRUE, name = "n_species_by_homeworld")
 species
 species \%>\%
- count(species, sort = TRUE) \%>\%
- rename(n_species = n)
+ count(species, sort = TRUE, name = "n_species")
 
 # add_count() is useful for groupwise filtering
 # e.g.: show details for species that have a single member

--- a/tests/testthat/test-count-tally.r
+++ b/tests/testthat/test-count-tally.r
@@ -33,6 +33,14 @@ test_that("grouped count includes group", {
   expect_equal(group_vars(res), "g")
 })
 
+test_that("counts variable with the same name as `name` parameter", {
+  df <- data.frame(g = c(1, 1, 2, 2, 2))
+
+  out <- df %>% count(g, name = "g")
+  expect_equal(names(out), c("g", "ng"))
+  expect_equal(out$ng, c(2, 3))
+})
+
 
 # add_count ---------------------------------------------------------------
 
@@ -59,6 +67,22 @@ test_that("add_count respects and preserves existing groups", {
   expect_groups(res, "g")
 })
 
+test_that("adds counts column with user-defined name", {
+  df <- data.frame(g = c(1, 1, 2, 2, 2))
+  name <- "new_name"
+
+  out <- df %>% add_count(g, name = name)
+  expect_equal(names(out), c("g", name))
+  expect_equal(out[[name]], c(2, 2, 3, 3, 3))
+})
+
+test_that("adds counts of a variable with the same name as user-defined `name` parameter", {
+  df <- data.frame(g = c(1, 1, 2, 2, 2))
+
+  out <- df %>% add_count(g, name = "g")
+  expect_equal(names(out), c("g", "ng"))
+  expect_equal(out$ng, c(2, 2, 3, 3, 3))
+})
 
 # tally -------------------------------------------------------------------
 
@@ -68,9 +92,16 @@ test_that("weighted tally drops NAs (#1145)", {
   expect_equal(tally(df, x)$n, 2)
 })
 
+test_that("tally outputs column with user-defined name", {
+  df <- data_frame(g = c(1, 2, 2, 2), val = c("b", "b", "b", "c"))
+  name <- "counts"
+  res <- df %>% tally(name = name)
+
+  expect_equal(names(res), name)
+})
+
 
 # add_tally ---------------------------------------------------------------
-
 
 test_that("can add tallies of a variable", {
   df <- data.frame(a = c(1, 1, 2, 2, 2))
@@ -103,4 +134,12 @@ test_that("add_tally can be given a weighting variable", {
 
   out <- df %>% group_by(a) %>% add_tally(wt = w + 1)
   expect_equal(out$n, c(4, 4, 12, 12, 12))
+})
+
+test_that("adds column with user-defined variable name", {
+  df <- data_frame(g = c(1, 2, 2, 2), val = c("b", "b", "b", "c"))
+  name <- "counts"
+  res <- df %>% add_tally(name = name)
+
+  expect_equal(names(res), c("g", "val", name))
 })


### PR DESCRIPTION
> There is currently no way to control the output variable name.

Following the premise that it would indeed be a good idea to add this functionality, I decided to give it a try, changing as little as possible the current functions. I've added a few tests, but maybe I'm missing some important corner cases. Feel free to disregard this if there's some reason not to do this (right now) or there's a more appropriate way. I noticed there's been some changes to the count/tally behavior in recent commits, so maybe this is not the best time.

```
> df <- data_frame(name = c("a", "b", "a"), money = c(10, 20, 100))
> count(df, name, name = "n_accounts")
# A tibble: 2 x 2
  name  n_accounts
  <chr>      <int>
1 a              2
2 b              1
```

Regarding using an already existing column name, I'm not sure this is the appropriate solution, but I decided to keep it equal to the behavior with `n`, with a message:
```
> df <- data_frame(name = c("a", "b", "a"), money = c(10, 20, 100))
> count(df, name, name = "name")
Column `name` already exists, using `nname` as output variable name
# A tibble: 2 x 2
  name  nname
  <chr> <int>
1 a         2
2 b         1
```

`add_tally` and `add_count` have the same behavior.